### PR TITLE
feat(calendar): Make summary parameter required in create_event function

### DIFF
--- a/calendar_mcp.py
+++ b/calendar_mcp.py
@@ -49,7 +49,7 @@ async def create_event(
     start: str,
     end: str,
     timeZone: str,
-    summary: str | None = None,
+    summary: str,
     description: str | None = None,
     location: str | None = None,
 ) -> str:
@@ -60,7 +60,7 @@ async def create_event(
         start (str): Event start time in ISO 8601 format (e.g., '2025-04-06T10:00:00-07:00').
         end (str): Event end time in ISO 8601 format (e.g., '2025-04-06T11:00:00-07:00').
         timeZone (str): User timezone formatted as an IANA Time Zone Database name (e.g. "Europe/Zurich").
-        summary (str, optional): Short title or subject of the event. Defaults to None.
+        summary (str): Short title or subject of the event.
         description (str, optional): Detailed description or notes for the event. Defaults to None.
         location (str, optional): Physical or virtual location of the event. Defaults to None.
     """

--- a/services.py
+++ b/services.py
@@ -173,7 +173,7 @@ async def create_event(
         start (str): Event start time in ISO 8601 format (e.g., '2025-04-06T10:00:00-04:00').
         end (str): Event end time in ISO 8601 format (e.g., '2025-04-06T11:00:00-04:00').
         timeZone (str): User timezone formatted as an IANA Time Zone Database name (e.g. "Europe/Zurich").
-        summary (str, optional): Short title or subject of the event. Defaults to None.
+        summary (str, optional): Short title or subject of the event.
         description (str, optional): Detailed description or notes for the event. Defaults to None.
         location (str, optional): Physical or virtual location of the event. Defaults to None.
     """


### PR DESCRIPTION
The summary parameter in the create_event function has been changed from optional to required. This change ensures that every event created must have a title or subject, improving the consistency and clarity of event data. This modification aligns with the business requirement that all events should have a descriptive summary for better user experience and data management.